### PR TITLE
Add kf:conf function

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,10 @@ Here are a few examples for the `kf` package:
 ;; will add to quicklisp soon, after docstrings are updated
 (ql:quickload :cl-rdkafka)
 
-(defparameter *conf* (make-hash-table :test #'equal))
-
-(setf (gethash "bootstrap.servers" *conf*) "127.0.0.1:9092")
-
 (let ((messages '(("key-1" "value-1") ("key-2" "value-2")))
       (producer (make-instance 'kf:producer
-                               :conf *conf*
+                               :conf (kf:conf
+				      "bootstrap.servers" "127.0.0.1:9092")
                                :key-serde #'kf:object->bytes
                                :value-serde #'kf:object->bytes)))
   (loop
@@ -50,20 +47,19 @@ Here are a few examples for the `kf` package:
 ```lisp
 (ql:quickload :cl-rdkafka)
 
-(defparameter *conf* (make-hash-table :test #'equal))
-
 ;; see librdkafka and kafka docs for config info
-(setf (gethash "bootstrap.servers" *conf*) "127.0.0.1:9092"
-      (gethash "group.id" *conf*) "consumer-group-id"
-      (gethash "enable.auto.commit" *conf*) "false"
-      (gethash "auto.offset.reset" *conf*) "earliest"
-      (gethash "offset.store.method" *conf*) "broker"
-      (gethash "enable.partition.eof" *conf*) "false")
 
 (let* ((string-serde (lambda (x)
                        (kf:bytes->object x 'string)))
+       (conf (kf:conf
+	      "bootstrap.servers" "127.0.0.1:9092"
+	      "group.id" "consumer-group-id"
+	      "enable.auto.commit" "false"
+	      "auto.offset.reset" "earliest"
+	      "offset.store.method" "broker"
+	      "enable.partition.eof"  "false"))
        (consumer (make-instance 'kf:consumer
-                                :conf *conf*
+                                :conf conf
                                 :key-serde string-serde
                                 :value-serde string-serde)))
   (kf:subscribe consumer '("topic-name"))

--- a/src/high-level/conf.lisp
+++ b/src/high-level/conf.lisp
@@ -34,6 +34,18 @@
 	       'cl-rdkafka/ll:rd-kafka-topic-conf-new)
 	handle)))
 
+;; TODO add use-value condition handler
+(defun conf (&rest key-vals)
+  "Construct a hash-table from the strings in key-vals."
+  (let ((h (make-hash-table :test #'equal)))
+    (loop
+       for (k v) on key-vals
+       by #'cddr
+       unless v
+       do (error "~&Odd number of key-val pairs: missing value for key `~A`" k)
+       else do (setf (gethash k h) v))
+    h))
+
 (defclass conf ()
   ((rd-kafka-conf
     :initform (new-conf)

--- a/src/high-level/package.lisp
+++ b/src/high-level/package.lisp
@@ -36,4 +36,6 @@
 
    #:future #:value
 
-   #:producer #:produce #:flush))
+   #:producer #:produce #:flush
+
+   #:conf))

--- a/test/high-level/conf.lisp
+++ b/test/high-level/conf.lisp
@@ -26,3 +26,18 @@
 	 (string= "foo" (kf::prop conf "client.id"))
 	 (string= "1024" (kf::prop conf "message.max.bytes"))
 	 (string= "foobar:9092" (kf::prop conf "bootstrap.servers"))))))
+
+(def-test conf-function ()
+  (let* ((expected '(("a" "A")
+		     ("b" "B")
+		     ("c" "C")
+		     ("d" "D")))
+	 (flattened (loop for (k v) in expected collect k collect v))
+	 (actual (eval `(kf:conf ,@flattened))))
+    (is (and
+	 (= (length expected) (hash-table-count actual))
+	 (every
+	  (lambda (key-val)
+	    (string= (cadr key-val)
+		     (gethash (car key-val) actual)))
+	  expected)))))

--- a/test/high-level/consumer.lisp
+++ b/test/high-level/consumer.lisp
@@ -17,13 +17,12 @@
 
 (in-package #:test/high-level/consumer)
 
-(defvar *conf* (make-hash-table :test #'equal))
-
-(setf (gethash "bootstrap.servers" *conf*) "kafka:9092")
-(setf (gethash "group.id" *conf*) (write-to-string (get-universal-time)))
-(setf (gethash "enable.auto.commit" *conf*) "true")
-(setf (gethash "auto.offset.reset" *conf*) "earliest")
-(setf (gethash "offset.store.method" *conf*) "broker")
+(defvar *conf* (kf:conf
+		"bootstrap.servers" "kafka:9092"
+		"group.id" (write-to-string (get-universal-time))
+		"enable.auto.commit" "true"
+		"auto.offset.reset" "earliest"
+		"offset.store.method" "broker"))
 
 (def-test consumer-subscribe ()
   (setf (gethash "group.id" *conf*) (write-to-string (get-universal-time)))

--- a/test/high-level/producer.lisp
+++ b/test/high-level/producer.lisp
@@ -17,9 +17,8 @@
 
 (in-package #:test/high-level/producer)
 
-(defvar *conf* (make-hash-table :test #'equal))
-
-(setf (gethash "bootstrap.servers" *conf*) "kafka:9092")
+(defvar *conf* (kf:conf
+		"bootstrap.servers" "kafka:9092"))
 
 (defun parse-kafkacat (output-lines)
   (flet ((parse (partition-key-value)


### PR DESCRIPTION
This gives us a more literal notation for creating a conf hash-table.

So, instead of:

    (let ((conf (make-hash-table :test #'equal)))
      (setf (gethash "bootstrap.servers" conf) "127.0.0.1:9092"
            (gethash "group.id" conf) "consumer-group-id")
      ...)

We can do:

    (let ((conf (kf:conf
                 "bootstrap.servers" "127.0.0.1:9092"
                 "group.id" "consumer-group-id")))
      ...)