### PR TITLE
Increase poll timeout in unit tests

### DIFF
--- a/test/high-level/produce->consume.lisp
+++ b/test/high-level/produce->consume.lisp
@@ -54,7 +54,7 @@
     (kf:subscribe consumer (list +topic+))
 
     (loop
-       for message = (kf:poll consumer (* 2 1000))
+       for message = (kf:poll consumer 5000)
        while message
 
        for key = (kf:key message)


### PR DESCRIPTION
The tests failed one time earlier because the timeout was just a
little too short.