### PR TITLE
[#64] s/produce->consume/produce-consume

### DIFF
--- a/cl-rdkafka.asd
+++ b/cl-rdkafka.asd
@@ -91,7 +91,7 @@
             :components
             ((:file "consumer")
              (:file "producer")
-             (:file "produce->consume")
+             (:file "produce-consume")
              (:file "admin")
              (:file "headers")
              (:file "transactions")))))

--- a/test/high-level/produce-consume.lisp
+++ b/test/high-level/produce-consume.lisp
@@ -17,10 +17,10 @@
 
 (in-package #:cl-user)
 
-(defpackage #:test/high-level/produce->consume
+(defpackage #:test/high-level/produce-consume
   (:use #:cl #:1am #:test))
 
-(in-package #:test/high-level/produce->consume)
+(in-package #:test/high-level/produce-consume)
 
 (defun produce-messages (topic)
   (let ((producer (make-instance
@@ -59,7 +59,7 @@
 
        do (kf:commit consumer))))
 
-(test produce->consume
+(test produce-consume
   (with-topics ((topic "test-produce-to-consume"))
     (let ((expected (produce-messages topic))
           (actual (consume-messages topic)))


### PR DESCRIPTION
`>` is an invalid filename char on Windows, which prevents the repo
from being cloned.