### PR TITLE
Error processing and logging

### DIFF
--- a/cl-rdkafka.asd
+++ b/cl-rdkafka.asd
@@ -21,7 +21,7 @@
   :version (:read-file-form "version.lisp")
   :author "Sahil Kang <sahil.kang@asilaycomputing.com>"
   :license "GPLv3"
-  :depends-on (#:cffi #:trivial-garbage #:bordeaux-threads #:lparallel)
+  :depends-on (#:cffi #:trivial-garbage #:bordeaux-threads #:lparallel #:log4cl)
   :defsystem-depends-on (#:cffi-grovel)
   :in-order-to ((test-op (test-op #:cl-rdkafka/test)))
   :build-pathname "cl-rdkafka"

--- a/src/high-level/conf.lisp
+++ b/src/high-level/conf.lisp
@@ -107,7 +107,11 @@
                (,set-keyval "client.software.version"
                             (format nil "v~A-librdkafka-v~A"
                                     (asdf:component-version
-                                     (asdf:find-system 'cl-rdkafka))
+                                     ;; Previously here was used a FIND-SYSTEM
+                                     ;; but it causes ASDF/PLAN:SYSTEM-OUT-OF-DATE error
+                                     ;; when cl-rdkafka is used:
+                                     ;; https://github.com/SahilKang/cl-rdkafka/issues/72
+                                     (asdf:registered-system 'cl-rdkafka))
                                     (cl-rdkafka/ll:rd-kafka-version-str)))
                ,@(when old-version-p
                    `((cl-rdkafka/ll:rd-kafka-conf-set-default-topic-conf


### PR DESCRIPTION
This PR adds some restarts into the POLL-LOOP, allowing to ignore error and continue polling.

Also, it shows real error messages from Kafka instead of:

```
Expected event-type `1`, not `8`
```